### PR TITLE
Fix not run Build with CI words in pull request comment.

### DIFF
--- a/src/main/scala/io/github/gitbucket/ci/hook/CIPullRequestHook.scala
+++ b/src/main/scala/io/github/gitbucket/ci/hook/CIPullRequestHook.scala
@@ -54,7 +54,7 @@ class CIPullRequestHook extends PullRequestHook
         buildAuthor  <- context.loginAccount
         buildConfig  <- loadCIConfig(pullreq.userName, pullreq.repositoryName)
       } yield {
-        if(buildConfig.runWordsSeq.find(content.contains).isEmpty){
+        if(!buildConfig.runWordsSeq.find(content.contains).isEmpty){
           val revCommit = using(Git.open(getRepositoryDir(pullreq.requestUserName, pullreq.requestRepositoryName))) { git =>
             val objectId = git.getRepository.resolve(pullreq.commitIdTo)
             JGitUtil.getRevCommitFromId(git, objectId)


### PR DESCRIPTION
This PR fixes to run only build when PR commented with run words. And do NOT run build another words, like skip words.
Fixes #53.