### PR TITLE
[WIP] add pages feature generated by CI

### DIFF
--- a/src/main/resources/update/gitbucket-ci_1.7.0.xml
+++ b/src/main/resources/update/gitbucket-ci_1.7.0.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changeSet>
+    <addColumn tableName="CI_CONFIG">
+        <column name="PAGES_DIR" type="varchar(200)" nullable="true"/>
+    </addColumn>
+</changeSet>

--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -54,7 +54,9 @@ class Plugin extends gitbucket.core.plugin.Plugin with CIService with AccountSer
     new Version("1.4.0",
       new LiquibaseMigration("update/gitbucket-ci_1.4.0.xml")),
     new Version("1.5.0",
-      new LiquibaseMigration("update/gitbucket-ci_1.5.0.xml"))
+      new LiquibaseMigration("update/gitbucket-ci_1.5.0.xml")),
+    new Version("1.6.0"),
+    new Version("1.7.0", new LiquibaseMigration("update/gitbucket-ci_1.7.0.xml"))
   )
 
   override val assetsMappings = Seq("/ci" -> "/gitbucket/ci/assets")

--- a/src/main/scala/io/github/gitbucket/ci/model/CIConfig.scala
+++ b/src/main/scala/io/github/gitbucket/ci/model/CIConfig.scala
@@ -14,7 +14,8 @@ trait CIConfigComponent { self: gitbucket.core.model.Profile =>
     val notification = column[Boolean]("NOTIFICATION")
     val skipWords = column[String]("SKIP_WORDS")
     val runWords = column[String]("RUN_WORDS")
-    def * = (userName, repositoryName, buildType, buildScript, notification, skipWords.?, runWords.?) <> (CIConfig.tupled, CIConfig.unapply)
+    val pagesDir = column[String]("PAGES_DIR")
+    def * = (userName, repositoryName, buildType, buildScript, notification, skipWords.?, runWords.?, pagesDir.?) <> (CIConfig.tupled, CIConfig.unapply)
   }
 }
 
@@ -25,7 +26,8 @@ case class CIConfig(
   buildScript: String,
   notification: Boolean,
   skipWords: Option[String],
-  runWords: Option[String]
+  runWords: Option[String],
+  pagesDir: Option[String]
 ){
   lazy val skipWordsSeq: Seq[String] = skipWords.map(_.split(",").map(_.trim).toSeq).getOrElse(Nil)
   lazy val runWordsSeq: Seq[String] = runWords.map(_.split(",").map(_.trim).toSeq).getOrElse(Nil)

--- a/src/main/twirl/gitbucket/ci/config.scala.html
+++ b/src/main/twirl/gitbucket/ci/config.scala.html
@@ -53,6 +53,10 @@
                 <label for="runWords">Run words</label> (comma-separated words)
                 <input type="text" name="runWords" id="runWords" class="form-control" value="@config.map(_.runWords).getOrElse("ok to test, test this please")">
               </fieldset>
+              <fieldset class="form-group">
+                <label for="pagesDir">Pages directory</label>
+                <input type="text" name="pagesDir" id="pagesDir" class="form-control" value="@config.map(_.pagesDir).getOrElse("")">
+              </fieldset>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR add pages feature like gitbucket-pages-plugin. In contrast to pages-plugin, it serves contents which generated by CI job.

This PR inspired by GitLab-CI pages. It makes more easy way to serve Static Site Generator's output.

**limitations**:

This PR isn't support "index.htm[l]" feature yet.

**notes**:

@takezoe did you forgot `new Version("1.6.0")` for ver.1.6.0 release?