### PR TITLE
Docker and docker-compose support

### DIFF
--- a/src/main/resources/update/gitbucket-ci_1.8.0.xml
+++ b/src/main/resources/update/gitbucket-ci_1.8.0.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changeSet>
+    <addColumn tableName="CI_SYSTEM_CONFIG">
+        <column name="ENABLE_DOCKER" type="boolean" nullable="true"/>
+        <column name="DOCKER_COMMAND" type="varchar(200)" nullable="true"/>
+    </addColumn>
+    <update tableName="CI_SYSTEM_CONFIG">
+        <column name="ENABLE_DOCKER" value="true"/>
+    </update>
+    <addNotNullConstraint tableName="CI_SYSTEM_CONFIG" columnName="ENABLE_DOCKER" columnDataType="boolean"/>
+</changeSet>

--- a/src/main/resources/update/gitbucket-ci_1.8.0.xml
+++ b/src/main/resources/update/gitbucket-ci_1.8.0.xml
@@ -3,9 +3,13 @@
     <addColumn tableName="CI_SYSTEM_CONFIG">
         <column name="ENABLE_DOCKER" type="boolean" nullable="true"/>
         <column name="DOCKER_COMMAND" type="varchar(200)" nullable="true"/>
+        <column name="ENABLE_DOCKER_COMPOSE" type="boolean" nullable="true"/>
+        <column name="DOCKER_COMPOSE_COMMAND" type="varchar(200)" nullable="true"/>
     </addColumn>
     <update tableName="CI_SYSTEM_CONFIG">
         <column name="ENABLE_DOCKER" value="false"/>
+        <column name="ENABLE_DOCKER_COMPOSE" value="false"/>
     </update>
     <addNotNullConstraint tableName="CI_SYSTEM_CONFIG" columnName="ENABLE_DOCKER" columnDataType="boolean"/>
+    <addNotNullConstraint tableName="CI_SYSTEM_CONFIG" columnName="ENABLE_DOCKER_COMPOSE" columnDataType="boolean"/>
 </changeSet>

--- a/src/main/resources/update/gitbucket-ci_1.8.0.xml
+++ b/src/main/resources/update/gitbucket-ci_1.8.0.xml
@@ -7,8 +7,8 @@
         <column name="DOCKER_COMPOSE_COMMAND" type="varchar(200)" nullable="true"/>
     </addColumn>
     <update tableName="CI_SYSTEM_CONFIG">
-        <column name="ENABLE_DOCKER" value="false"/>
-        <column name="ENABLE_DOCKER_COMPOSE" value="false"/>
+        <column name="ENABLE_DOCKER" valueBoolean="false"/>
+        <column name="ENABLE_DOCKER_COMPOSE" valueBoolean="false"/>
     </update>
     <addNotNullConstraint tableName="CI_SYSTEM_CONFIG" columnName="ENABLE_DOCKER" columnDataType="boolean"/>
     <addNotNullConstraint tableName="CI_SYSTEM_CONFIG" columnName="ENABLE_DOCKER_COMPOSE" columnDataType="boolean"/>

--- a/src/main/resources/update/gitbucket-ci_1.8.0.xml
+++ b/src/main/resources/update/gitbucket-ci_1.8.0.xml
@@ -5,7 +5,7 @@
         <column name="DOCKER_COMMAND" type="varchar(200)" nullable="true"/>
     </addColumn>
     <update tableName="CI_SYSTEM_CONFIG">
-        <column name="ENABLE_DOCKER" value="true"/>
+        <column name="ENABLE_DOCKER" value="false"/>
     </update>
     <addNotNullConstraint tableName="CI_SYSTEM_CONFIG" columnName="ENABLE_DOCKER" columnDataType="boolean"/>
 </changeSet>

--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -61,7 +61,9 @@ class Plugin extends gitbucket.core.plugin.Plugin with CIService with AccountSer
     new Version("1.6.2"),
     new Version("1.6.3"),
     new Version("1.6.4"),
-    new Version("1.7.0")
+    new Version("1.7.0"),
+    new Version("1.8.0",
+      new LiquibaseMigration("update/gitbucket-ci_1.8.0.xml"))
   )
 
   override val assetsMappings = Seq("/ci" -> "/gitbucket/ci/assets")

--- a/src/main/scala/io/github/gitbucket/ci/controller/CIController.scala
+++ b/src/main/scala/io/github/gitbucket/ci/controller/CIController.scala
@@ -326,7 +326,7 @@ class CIController extends ControllerBase
           (buildType match {
             case "script" => form.buildScript.getOrElse("")
             case "file" => form.buildFile.getOrElse("")
-            case "docker" => form.dockerfile.getOrElse("Dockerfile")
+            case "docker" => form.dockerfile.getOrElse("")
             case _ => ""
           }),
           form.notification,

--- a/src/main/scala/io/github/gitbucket/ci/controller/CIController.scala
+++ b/src/main/scala/io/github/gitbucket/ci/controller/CIController.scala
@@ -71,7 +71,7 @@ class CIController extends ControllerBase
     "buildType" -> trim(label("Build type", optionalRequiredIfChecked("enableBuild", text()))),
     "buildScript" -> trim(label("Build script", optionalRequired(_("buildType") == Seq("script"), text()))),
     "buildFile" -> trim(label("Build file", optionalRequired(_("buildType") == Seq("file"), text()))),
-    "dockerfile" -> trim(label("Dockerfile", optionalRequired(_("buildType") == Seq("docker"), text()))),
+    "dockerfile" -> trim(label("Dockerfile", optional(text()))),
     "notification" -> trim(label("Notification", boolean())),
     "skipWords" -> trim(label("Skip words", optional(text()))),
     "runWords" -> trim(label("Run words", optional(text())))
@@ -326,7 +326,7 @@ class CIController extends ControllerBase
           (buildType match {
             case "script" => form.buildScript.getOrElse("")
             case "file" => form.buildFile.getOrElse("")
-            case "docker" => form.dockerfile.getOrElse("")
+            case "docker" => form.dockerfile.getOrElse("Dockerfile")
             case _ => ""
           }),
           form.notification,

--- a/src/main/scala/io/github/gitbucket/ci/controller/CIController.scala
+++ b/src/main/scala/io/github/gitbucket/ci/controller/CIController.scala
@@ -322,7 +322,7 @@ class CIController extends ControllerBase
           (buildType match {
             case "script" => form.buildScript.getOrElse("")
             case "file" => form.buildFile.getOrElse("")
-            case "docker" => "Dockerfile"
+            case "docker" => form.dockerfile.getOrElse("")
             case _ => ""
           }),
           form.notification,

--- a/src/main/scala/io/github/gitbucket/ci/controller/CIController.scala
+++ b/src/main/scala/io/github/gitbucket/ci/controller/CIController.scala
@@ -46,6 +46,7 @@ object CIController {
     buildType: Option[String],
     buildScript: Option[String],
     buildFile: Option[String],
+    dockerfile: Option[String],
     notification: Boolean,
     skipWords: Option[String],
     runWords: Option[String]
@@ -68,6 +69,7 @@ class CIController extends ControllerBase
     "buildType" -> trim(label("Build type", optionalRequiredIfChecked("enableBuild", text()))),
     "buildScript" -> trim(label("Build script", optionalRequired(_("buildType") == Seq("script"), text()))),
     "buildFile" -> trim(label("Build file", optionalRequired(_("buildType") == Seq("file"), text()))),
+    "dockerfile" -> trim(label("Dockerfile", optionalRequired(_("buildType") == Seq("docker"), text()))),
     "notification" -> trim(label("Notification", boolean())),
     "skipWords" -> trim(label("Skip words", optional(text()))),
     "runWords" -> trim(label("Run words", optional(text())))
@@ -320,6 +322,7 @@ class CIController extends ControllerBase
           (buildType match {
             case "script" => form.buildScript.getOrElse("")
             case "file" => form.buildFile.getOrElse("")
+            case "docker" => "Dockerfile"
             case _ => ""
           }),
           form.notification,

--- a/src/main/scala/io/github/gitbucket/ci/manager/BuildJobThread.scala
+++ b/src/main/scala/io/github/gitbucket/ci/manager/BuildJobThread.scala
@@ -229,7 +229,7 @@ class BuildJobThread(queue: LinkedBlockingQueue[BuildJob], threads: LinkedBlocki
 
     val exitValue = process.exitValue()
     if(exitValue != 0){
-      sb.append(s"EXIT CODE: ${exitValue}")
+      sb.append(s"EXIT CODE: ${exitValue}\n")
     }
     exitValue
   }
@@ -253,8 +253,10 @@ class BuildJobThread(queue: LinkedBlockingQueue[BuildJob], threads: LinkedBlocki
     val buildContainerCommand = s"${dockerCommand} build -f ${job.config.buildScript} -t ${tagName} ${workspaceDir.getAbsolutePath}"
     val runContainerCommand = s"${dockerCommand} run --rm --name ${containerName} ${tagName}"
 
+    sb.append(s"${buildContainerCommand}\n")
     val buildResult = runProcess(job, buildDir, workspaceDir, buildContainerCommand)
     if (buildResult == 0){
+      sb.append(s"${runContainerCommand}\n")
       runProcess(job, buildDir, workspaceDir, runContainerCommand)
     }else{
       buildResult

--- a/src/main/scala/io/github/gitbucket/ci/manager/BuildJobThread.scala
+++ b/src/main/scala/io/github/gitbucket/ci/manager/BuildJobThread.scala
@@ -268,7 +268,6 @@ class BuildJobThread(queue: LinkedBlockingQueue[BuildJob], threads: LinkedBlocki
       val exitCode = runProcess(job, buildDir, workspaceDir, runContainerCommand)
 
       val imageId = Process(s"""${dockerCommand} images --format "{{.ID}}" ${tagName}""").!!.stripLineEnd
-      println(imageId)
       val rmImageCommand = s"${dockerCommand} rmi --force ${imageId}"
       sb.append(s"$rmImageCommand\n")
       runProcess(job, buildDir, workspaceDir, rmImageCommand)

--- a/src/main/scala/io/github/gitbucket/ci/manager/BuildJobThread.scala
+++ b/src/main/scala/io/github/gitbucket/ci/manager/BuildJobThread.scala
@@ -126,10 +126,10 @@ class BuildJobThread(queue: LinkedBlockingQueue[BuildJob], threads: LinkedBlocki
                 throw new RuntimeException("Docker job is disabled.")
               }
             case "docker-compose" =>
-              if(systemCIConfig.enableDocker){
+              if(systemCIConfig.enableDockerCompose){
                 runDockerComposeJob(job, buildDir, dir, dockerComposeCommand)
               }else{
-                throw new RuntimeException("Docker job is disabled.")
+                throw new RuntimeException("Docker compose job is disabled.")
               }
             case _ =>
               throw new MatchError("Invalid build type: " + job.config.buildType)

--- a/src/main/scala/io/github/gitbucket/ci/model/CISystemConfig.scala
+++ b/src/main/scala/io/github/gitbucket/ci/model/CISystemConfig.scala
@@ -9,11 +9,15 @@ trait CISystemConfigComponent { self: gitbucket.core.model.Profile =>
   class CISystemConfigs(tag: Tag) extends Table[CISystemConfig](tag, "CI_SYSTEM_CONFIG") {
     val maxBuildHistory = column[Int]("MAX_BUILD_HISTORY")
     val maxParallelBuilds = column[Int]("MAX_PARALLEL_BUILDS")
-    def * = (maxBuildHistory, maxParallelBuilds) <> (CISystemConfig.tupled, CISystemConfig.unapply)
+    val enableDocker = column[Boolean]("ENABLE_DOCKER")
+    val dockerCommand = column[String]("DOCKER_COMMAND")
+    def * = (maxBuildHistory, maxParallelBuilds, enableDocker, dockerCommand.?) <> (CISystemConfig.tupled, CISystemConfig.unapply)
   }
 }
 
 case class CISystemConfig(
   maxBuildHistory: Int,
-  maxParallelBuilds: Int
+  maxParallelBuilds: Int,
+  enableDocker: Boolean,
+  dockerCommand: Option[String]
 )

--- a/src/main/scala/io/github/gitbucket/ci/model/CISystemConfig.scala
+++ b/src/main/scala/io/github/gitbucket/ci/model/CISystemConfig.scala
@@ -11,7 +11,9 @@ trait CISystemConfigComponent { self: gitbucket.core.model.Profile =>
     val maxParallelBuilds = column[Int]("MAX_PARALLEL_BUILDS")
     val enableDocker = column[Boolean]("ENABLE_DOCKER")
     val dockerCommand = column[String]("DOCKER_COMMAND")
-    def * = (maxBuildHistory, maxParallelBuilds, enableDocker, dockerCommand.?) <> (CISystemConfig.tupled, CISystemConfig.unapply)
+    val enableDockerCompose = column[Boolean]("ENABLE_DOCKER_COMPOSE")
+    val dockerComposeCommand = column[String]("DOCKER_COMPOSE_COMMAND")
+    def * = (maxBuildHistory, maxParallelBuilds, enableDocker, dockerCommand.?, enableDockerCompose, dockerComposeCommand.?) <> (CISystemConfig.tupled, CISystemConfig.unapply)
   }
 }
 
@@ -19,5 +21,7 @@ case class CISystemConfig(
   maxBuildHistory: Int,
   maxParallelBuilds: Int,
   enableDocker: Boolean,
-  dockerCommand: Option[String]
+  dockerCommand: Option[String],
+  enableDockerCompose: Boolean,
+  dockerComposeCommand: Option[String]
 )

--- a/src/main/scala/io/github/gitbucket/ci/service/CIService.scala
+++ b/src/main/scala/io/github/gitbucket/ci/service/CIService.scala
@@ -51,8 +51,8 @@ trait CIService { self: AccountService with RepositoryService =>
 
   def saveCISystemConfig(config: CISystemConfig)(implicit s: Session): Unit = {
     CISystemConfigs.map { t =>
-      (t.maxBuildHistory, t.maxParallelBuilds, t.enableDocker, t.dockerCommand.?)
-    }.update((config.maxBuildHistory, config.maxParallelBuilds, config.enableDocker, config.dockerCommand))
+      (t.maxBuildHistory, t.maxParallelBuilds, t.enableDocker, t.dockerCommand.?, t.enableDockerCompose, t.dockerComposeCommand.?)
+    }.update((config.maxBuildHistory, config.maxParallelBuilds, config.enableDocker, config.dockerCommand, config.enableDockerCompose, config.dockerComposeCommand))
   }
 
   def loadCISystemConfig()(implicit s: Session): CISystemConfig = {

--- a/src/main/scala/io/github/gitbucket/ci/service/CIService.scala
+++ b/src/main/scala/io/github/gitbucket/ci/service/CIService.scala
@@ -51,8 +51,8 @@ trait CIService { self: AccountService with RepositoryService =>
 
   def saveCISystemConfig(config: CISystemConfig)(implicit s: Session): Unit = {
     CISystemConfigs.map { t =>
-      (t.maxBuildHistory, t.maxParallelBuilds)
-    }.update((config.maxBuildHistory, config.maxParallelBuilds))
+      (t.maxBuildHistory, t.maxParallelBuilds, t.enableDocker, t.dockerCommand.?)
+    }.update((config.maxBuildHistory, config.maxParallelBuilds, config.enableDocker, config.dockerCommand))
   }
 
   def loadCISystemConfig()(implicit s: Session): CISystemConfig = {

--- a/src/main/twirl/gitbucket/ci/config.scala.html
+++ b/src/main/twirl/gitbucket/ci/config.scala.html
@@ -1,5 +1,6 @@
 @(repository: gitbucket.core.service.RepositoryService.RepositoryInfo,
   config: Option[io.github.gitbucket.ci.model.CIConfig],
+  systemConfig: io.github.gitbucket.ci.model.CISystemConfig,
   info: Option[Any])(implicit context: gitbucket.core.controller.Context)
 @import gitbucket.core.view.helpers._
 @gitbucket.core.html.main(s"Build - ${repository.owner}/${repository.name}", Some(repository)) {
@@ -17,7 +18,7 @@
               </label>
             </fieldset>
             <div id="buildSettings">
-              <fielset class="form-group">
+              <fieldset class="form-group">
                 <div>
                   <span id="error-buildType" class="error"></span>
                 </div>
@@ -35,14 +36,16 @@
                   </label>
                   <input id="buildFile" name="buildFile" class="form-control" value="@config.filter(_.buildType == "file").map(_.buildScript)">
                   <span id="error-buildFile" class="error"></span>
-                <label>
-                  <input type="radio" name="buildType" value="docker" @if(config.exists(_.buildType == "docker")){checked}>
-                  Build in docker
-                  <span class="normal muted">(Specify a Dockerfile in your repository to build this project)</span>
-                </label>
-                <input id="dockerfile" name="dockerfile" class="form-control" value="@config.filter(_.buildType == "docker").map(_.buildScript)">
-                <span id="error-dockerfile" class="error"></span>
-              </fielset>
+                  @if(systemConfig.enableDocker) {
+                      <label>
+                          <input type="radio" name="buildType" value="docker" @if(config.exists(_.buildType == "docker")){checked}>
+                          Build in docker
+                          <span class="normal muted">(Specify a Dockerfile in your repository to build this project)</span>
+                      </label>
+                      <input id="dockerfile" name="dockerfile" class="form-control" value="@config.filter(_.buildType == "docker").map(_.buildScript)">
+                      <span id="error-dockerfile" class="error"></span>
+                  }
+              </fieldset>
               <fieldset class="form-group">
                 <label class="checkbox" for="notification">
                   <input type="checkbox" id="notification" name="notification"@if(config.exists(_.notification)){ checked}/>

--- a/src/main/twirl/gitbucket/ci/config.scala.html
+++ b/src/main/twirl/gitbucket/ci/config.scala.html
@@ -35,6 +35,13 @@
                   </label>
                   <input id="buildFile" name="buildFile" class="form-control" value="@config.filter(_.buildType == "file").map(_.buildScript)">
                   <span id="error-buildFile" class="error"></span>
+                <label>
+                  <input type="radio" name="buildType" value="docker" @if(config.exists(_.buildType == "docker")){checked}>
+                  Build in docker
+                  <span class="normal muted">(Specify a Dockerfile in your repository to build this project)</span>
+                </label>
+                <input id="dockerfile" name="dockerfile" class="form-control" value="@config.filter(_.buildType == "docker").map(_.buildScript)">
+                <span id="error-dockerfile" class="error"></span>
               </fielset>
               <fieldset class="form-group">
                 <label class="checkbox" for="notification">

--- a/src/main/twirl/gitbucket/ci/config.scala.html
+++ b/src/main/twirl/gitbucket/ci/config.scala.html
@@ -44,6 +44,8 @@
                       </label>
                       <input id="dockerfile" name="dockerfile" class="form-control" value="@config.filter(_.buildType == "docker").map(_.buildScript)">
                       <span id="error-dockerfile" class="error"></span>
+                  }
+                  @if(systemConfig.enableDockerCompose){
                       <label>
                           <input type="radio" name="buildType" value="docker-compose" @if(config.exists(_.buildType == "docker-compose")){checked}>
                           Build in docker compose

--- a/src/main/twirl/gitbucket/ci/config.scala.html
+++ b/src/main/twirl/gitbucket/ci/config.scala.html
@@ -91,6 +91,8 @@ function updateStatus(){
       $('textarea[name=buildScript]').prop('disabled', false);
     } else if(buildType == 'file'){
       $('input[name=buildFile]').prop('disabled', false);
+    } else if(buildType == 'docker'){
+      $('input[name=dockerfile').prop('disabled', false);
     }
   } else {
     // Disables all fields

--- a/src/main/twirl/gitbucket/ci/config.scala.html
+++ b/src/main/twirl/gitbucket/ci/config.scala.html
@@ -44,6 +44,13 @@
                       </label>
                       <input id="dockerfile" name="dockerfile" class="form-control" value="@config.filter(_.buildType == "docker").map(_.buildScript)">
                       <span id="error-dockerfile" class="error"></span>
+                      <label>
+                          <input type="radio" name="buildType" value="docker-compose" @if(config.exists(_.buildType == "docker-compose")){checked}>
+                          Build in docker compose
+                          <span class="normal muted">(Specify a docker-compose.yml in your repository to build this project)</span>
+                      </label>
+                      <input id="composeFile" name="composeFile" class="form-control" value="@config.filter(_.buildType == "docker-compose").map(_.buildScript)">
+                      <span id="error-composeFile" class="error"></span>
                   }
               </fieldset>
               <fieldset class="form-group">
@@ -96,6 +103,8 @@ function updateStatus(){
       $('input[name=buildFile]').prop('disabled', false);
     } else if(buildType == 'docker'){
       $('input[name=dockerfile').prop('disabled', false);
+    } else if(buildType == 'docker-compose'){
+      $('input[name=composeFile]').prop('disabled', false);
     }
   } else {
     // Disables all fields

--- a/src/main/twirl/gitbucket/ci/system.scala.html
+++ b/src/main/twirl/gitbucket/ci/system.scala.html
@@ -18,6 +18,19 @@
             <span id="error-maxParallelBuilds" class="error"></span>
           </div>
         </div>
+        <div class="form-group">
+          <label class="checkbox" for="enableDocker">
+            <input type="checkbox" id="enableDocker" name="enableDocker"@if(systemConfig.enableDocker){ checked}/>
+            Enable docker
+          </label>
+        </div>
+        <div class="form-group">
+          <label class="control-label col-md-2" for="dockerCommand">Docker command</label>
+          <div class="col-md-10">
+            <input type="input" name="dockerCommand" id="dockerCommand" class="form-control" value="@systemConfig.dockerCommand.getOrElse("")" placeholder="docker">
+            <span id="error-dockerCommand" class="error"></span>
+          </div>
+        </div>
         <div class="align-right" style="margin-top: 20px;">
           <input type="submit" class="btn btn-success" value="Apply changes"/>
         </div>

--- a/src/main/twirl/gitbucket/ci/system.scala.html
+++ b/src/main/twirl/gitbucket/ci/system.scala.html
@@ -31,6 +31,19 @@
             <span id="error-dockerCommand" class="error"></span>
           </div>
         </div>
+        <div class="form-group">
+          <label class="checkbox" for="enableDockerCompose">
+            <input type="checkbox" id="enableDockerCompose" name="enableDockerCompose"@if(systemConfig.enableDockerCompose){ checked}/>
+            Enable docker compose
+          </label>
+        </div>
+        <div class="form-group">
+          <label class="control-label col-md-2" for="dockerComposeCommand">docker-compose command</label>
+          <div class="col-md-10">
+            <input type="input" name="dockerComposeCommand" id="dockerComposeCommand" class="form-control" value="@systemConfig.dockerComposeCommand.getOrElse("")" placeholder="docker-compose">
+            <span id="error-dockerComposeCommand" class="error"></span>
+          </div>
+        </div>
         <div class="align-right" style="margin-top: 20px;">
           <input type="submit" class="btn btn-success" value="Apply changes"/>
         </div>


### PR DESCRIPTION
In this PR, I add basic docker & docker-compose support to docker-ci plugin. It can close #22.

- Administrator can choose enable/disable docker/docker-compose
- also can specify docker (or docker-compose) command. (e.g. Ubuntu with snap: /snap/bin/docker)
- user can specify Dockerfie/docker-compose.yml path
    - currently, docker-compose servicename is restricted to "ci"

I only tested this PR on Windows 10 Pro.