### PR TITLE
Add a function to run build after PR merging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "gitbucket-ci-plugin"
 organization := "io.github.gitbucket"
-version := "1.9.0"
+version := "1.9.1"
 scalaVersion := "2.13.0"
 gitbucketVersion := "4.32.0"
 scalacOptions += "-deprecation"

--- a/src/main/resources/update/gitbucket-ci_1.9.1.xml
+++ b/src/main/resources/update/gitbucket-ci_1.9.1.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changeSet>
+    <addColumn tableName="CI_CONFIG">
+        <column name="RUN_AFTER_MERGE" type="boolean" nullable="true"/>
+    </addColumn>
+    <update tableName="CI_CONFIG">
+        <column name="RUN_AFTER_MERGE" valueBoolean="false"/>
+    </update>
+    <addNotNullConstraint tableName="CI_CONFIG" columnName="RUN_AFTER_MERGE" columnDataType="boolean"/>
+</changeSet>

--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -65,7 +65,9 @@ class Plugin extends gitbucket.core.plugin.Plugin with CIService with AccountSer
     new Version("1.8.0",
       new LiquibaseMigration("update/gitbucket-ci_1.8.0.xml")),
     new Version("1.8.1"),
-    new Version("1.9.0")
+    new Version("1.9.0"),
+    new Version("1.9.1",
+      new LiquibaseMigration("update/gitbucket-ci_1.9.1.xml"))
   )
 
   override val assetsMappings = Seq("/ci" -> "/gitbucket/ci/assets")

--- a/src/main/scala/io/github/gitbucket/ci/controller/CIController.scala
+++ b/src/main/scala/io/github/gitbucket/ci/controller/CIController.scala
@@ -50,6 +50,7 @@ object CIController {
     dockerfile: Option[String],
     composeFile: Option[String],
     notification: Boolean,
+    runAfterMerge: Boolean,
     skipWords: Option[String],
     runWords: Option[String]
   )
@@ -78,6 +79,7 @@ class CIController extends ControllerBase
     "dockerfile" -> trim(label("Dockerfile", optional(text()))),
     "composeFile" -> trim(label("docker-compose.yml", optional(text()))),
     "notification" -> trim(label("Notification", boolean())),
+    "runAfterMerge" -> trim(label("Run after merge", boolean())),
     "skipWords" -> trim(label("Skip words", optional(text()))),
     "runWords" -> trim(label("Run words", optional(text())))
   )(BuildConfigForm.apply)
@@ -338,6 +340,7 @@ class CIController extends ControllerBase
             case _ => ""
           }),
           form.notification,
+          form.runAfterMerge,
           form.skipWords,
           form.runWords
         )

--- a/src/main/scala/io/github/gitbucket/ci/model/CIConfig.scala
+++ b/src/main/scala/io/github/gitbucket/ci/model/CIConfig.scala
@@ -14,9 +14,10 @@ trait CIConfigComponent { self: gitbucket.core.model.Profile =>
     val buildType = column[String]("BUILD_TYPE")
     val buildScript = column[String]("BUILD_SCRIPT")
     val notification = column[Boolean]("NOTIFICATION")
+    val runAfterMerge = column[Boolean]("RUN_AFTER_MERGE")
     val skipWords = column[String]("SKIP_WORDS")
     val runWords = column[String]("RUN_WORDS")
-    def * = (userName, repositoryName, buildType, buildScript, notification, skipWords.?, runWords.?) <> (CIConfig.tupled, CIConfig.unapply)
+    def * = (userName, repositoryName, buildType, buildScript, notification, runAfterMerge, skipWords.?, runWords.?) <> (CIConfig.tupled, CIConfig.unapply)
   }
 }
 
@@ -26,6 +27,7 @@ case class CIConfig(
   buildType: String,
   buildScript: String,
   notification: Boolean,
+  runAfterMerge: Boolean,
   skipWords: Option[String],
   runWords: Option[String]
 ){

--- a/src/main/twirl/gitbucket/ci/config.scala.html
+++ b/src/main/twirl/gitbucket/ci/config.scala.html
@@ -65,6 +65,12 @@
                 </label>
               </fieldset>
               <fieldset class="form-group">
+                <label class="checkbox" for="runAfterMerge">
+                  <input type="checkbox" id="runAfterMerge" name="runAfterMerge"@if(config.exists(_.runAfterMerge)){ checked}/>
+                  Run a build script after the merge
+                </label>
+              </fieldset>
+              <fieldset class="form-group">
                 <label for="skipWords">Skip words</label> (comma-separated words)
                 <input type="text" name="skipWords" class="form-control" id="skipWords" value="@config.map(_.skipWords).getOrElse("[ci skip], [skip ci]")">
               </fieldset>


### PR DESCRIPTION
Add a function to run build after PR merging.
- Add a function.
- Add a checkbox to control this behavior in the settings menu like a following image.
- Add a xml for updating a database schema.

![added_run_build_after_merging](https://user-images.githubusercontent.com/4500808/66029195-cb680800-e539-11e9-9e67-0bb762ca11a3.png)
